### PR TITLE
Running container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:latest
 RUN apk update && apk add bash jq curl
 COPY dyn_dns.sh /opt/dyn_dns.sh
-RUN chmod +x /opt/dyn_dns.sh
+RUN adduser -D dyndns_user
+RUN chown dyndns_user:dyndns_user /opt/dyn_dns.sh
+RUN chmod 550 /opt/dyn_dns.sh
+USER dyndns_user
 ENTRYPOINT ["/opt/dyn_dns.sh"]


### PR DESCRIPTION
* Added adduser -D dyndns_user so the container will run the script as non-root
* Added chmod 550 so that only the dyndns_user has r-x to the script file